### PR TITLE
fix: wrong paths ends

### DIFF
--- a/relay/cmd.go
+++ b/relay/cmd.go
@@ -129,10 +129,10 @@ func activateClientCmd(ctx *config.Context) *cobra.Command {
 				counterparty *core.ProvableChain
 			)
 			if viper.GetBool(flagSrc) {
-				pathEnd = path.Src
+				pathEnd = path.Dst
 				target, counterparty = c[src], c[dst]
 			} else {
-				pathEnd = path.Dst
+				pathEnd = path.Src
 				target, counterparty = c[dst], c[src]
 			}
 			return activateClient(pathEnd, target, counterparty, viper.GetDuration(flagRetryInterval), viper.GetUint(flagRetryMaxAttempts))


### PR DESCRIPTION
I believe when activating the client the path ends should be chosen exactly the other way around. When activating the client for the src chain the path end of the dst chain should be selected and vice versa. In the lcp bridge demo repository this does not surface, because the client ids are always the same on the counterparty chains. But in production cases the lcp client ids might actually differ.