### PR TITLE
Fix to avoid referring to counterparty chain in `update-elc` command

### DIFF
--- a/relay/cmd.go
+++ b/relay/cmd.go
@@ -192,15 +192,12 @@ func updateELCCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 			var (
-				target       *core.ProvableChain
-				counterparty *core.ProvableChain
+				target *core.ProvableChain
 			)
 			if viper.GetBool(flagSrc) {
 				target = c[src]
-				counterparty = c[dst]
 			} else {
 				target = c[dst]
-				counterparty = c[src]
 			}
 			prover := target.Prover.(*Prover)
 			var elcClientID string
@@ -209,7 +206,7 @@ func updateELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doUpdateELC(elcClientID, counterparty)
+			out, err := prover.doUpdateELC(elcClientID)
 			if err != nil {
 				return err
 			}

--- a/relay/lcp.go
+++ b/relay/lcp.go
@@ -555,9 +555,14 @@ type UpdateELCResult struct {
 	Messages []*lcptypes.UpdateStateProxyMessage `json:"messages"`
 }
 
-func (pr *Prover) doUpdateELC(elcClientID string, counterparty core.FinalityAwareChain) (*UpdateELCResult, error) {
-	if err := pr.UpdateEKIfNeeded(context.TODO(), counterparty); err != nil {
-		return nil, err
+func (pr *Prover) doUpdateELC(elcClientID string) (*UpdateELCResult, error) {
+	if pr.activeEnclaveKey == nil {
+		eki, err := pr.selectNewEnclaveKey(context.TODO())
+		if err != nil {
+			return nil, err
+		}
+		pr.getLogger().Info("use a new enclave key", "enclave_key", hex.EncodeToString(eki.EnclaveKeyAddress))
+		pr.activeEnclaveKey = eki
 	}
 	pr.getLogger().Info("try to update the ELC client", "elc_client_id", elcClientID)
 	updates, err := pr.updateELC(elcClientID, false)


### PR DESCRIPTION
This is helpful for ELC tests without deploying LCPClient.