### PR TITLE
Add context.Context to Prover methods and Signer methods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/deckarep/golang-set/v2 v2.6.0
 	github.com/ethereum/go-ethereum v1.14.12
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/hyperledger-labs/yui-relayer v0.5.10
+	github.com/hyperledger-labs/yui-relayer v0.5.11
 	github.com/oasisprotocol/oasis-core/go v0.2201.11
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -728,8 +728,8 @@ github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0Jr
 github.com/huandu/skiplist v1.2.0 h1:gox56QD77HzSC0w+Ws3MH3iie755GBJU1OER3h5VsYw=
 github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXMrPiHF9w=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger-labs/yui-relayer v0.5.10 h1:j35SRowNfVDU3gvq4Th3Wy8ufRD5K4wbXDLQAGOgT8w=
-github.com/hyperledger-labs/yui-relayer v0.5.10/go.mod h1:kJvSmuagdDsSlvbnHtEHbhmkUlAS43/ArLDwukOKSlo=
+github.com/hyperledger-labs/yui-relayer v0.5.11 h1:tBDWJa96jQhxL9zLDbB94VvSgw0f8Xk9tqPuKMT3ARw=
+github.com/hyperledger-labs/yui-relayer v0.5.11/go.mod h1:kJvSmuagdDsSlvbnHtEHbhmkUlAS43/ArLDwukOKSlo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/relay/operator.go
+++ b/relay/operator.go
@@ -54,7 +54,7 @@ func (pr *Prover) updateOperators(counterparty core.Chain, nonce uint64, newOper
 	if threshold.Numerator > threshold.Denominator {
 		return fmt.Errorf("new operators threshold numerator cannot be greater than denominator: %s", threshold.String())
 	}
-	cplatestHeight, err := counterparty.LatestHeight()
+	cplatestHeight, err := counterparty.LatestHeight(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (pr *Prover) updateOperators(counterparty core.Chain, nonce uint64, newOper
 	if err != nil {
 		return err
 	}
-	if _, err := counterparty.SendMsgs([]sdk.Msg{msg}); err != nil {
+	if _, err := counterparty.SendMsgs(context.TODO(), []sdk.Msg{msg}); err != nil {
 		return err
 	}
 	return nil
@@ -129,11 +129,11 @@ func NewEIP712Signer(signer signer.Signer) *EIP712Signer {
 }
 
 func (s EIP712Signer) Sign(commitment [32]byte) ([]byte, error) {
-	return s.signer.Sign(commitment[:])
+	return s.signer.Sign(context.TODO(), commitment[:])
 }
 
 func (s EIP712Signer) GetSignerAddress() (common.Address, error) {
-	pub, err := s.signer.GetPublicKey()
+	pub, err := s.signer.GetPublicKey(context.TODO())
 	if err != nil {
 		return common.Address{}, err
 	}

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -149,7 +149,7 @@ func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, er
 
 // SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
 // The order of the returned header slice should be as: [<intermediate headers>..., <update header>]
-// if the header slice's length == nil and err == nil, the relayer should skips the update-client
+// if the header slice's length == nil and err == nil, the relayer should skip the update-client
 func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
 	if err := pr.UpdateEKIfNeeded(context.TODO(), dstChain); err != nil {
 		return nil, err

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -108,7 +108,7 @@ func (pr *Prover) GetChainID() string {
 // CreateInitialLightClientState returns a pair of ClientState and ConsensusState based on the state of the self chain at `height`.
 // These states will be submitted to the counterparty chain as MsgCreateClient.
 // If `height` is nil, the latest finalized height is selected automatically.
-func (pr *Prover) CreateInitialLightClientState(height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
+func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height exported.Height) (exported.ClientState, exported.ConsensusState, error) {
 	ops, err := pr.GetOperators()
 	if err != nil {
 		return nil, nil, err
@@ -143,19 +143,19 @@ func (pr *Prover) CreateInitialLightClientState(height exported.Height) (exporte
 
 // GetLatestFinalizedHeader returns the latest finalized header on this chain
 // The returned header is expected to be the latest one of headers that can be verified by the light client
-func (pr *Prover) GetLatestFinalizedHeader() (core.Header, error) {
-	return pr.originProver.GetLatestFinalizedHeader()
+func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, error) {
+	return pr.originProver.GetLatestFinalizedHeader(context.TODO())
 }
 
 // SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
 // The order of the returned header slice should be as: [<intermediate headers>..., <update header>]
 // if the header slice's length == nil and err == nil, the relayer should skips the update-client
-func (pr *Prover) SetupHeadersForUpdate(dstChain core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
+func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
 	if err := pr.UpdateEKIfNeeded(context.TODO(), dstChain); err != nil {
 		return nil, err
 	}
 
-	headers, err := pr.originProver.SetupHeadersForUpdate(dstChain, latestFinalizedHeader)
+	headers, err := pr.originProver.SetupHeadersForUpdate(context.TODO(), dstChain, latestFinalizedHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup headers for update: header=%v %w", latestFinalizedHeader, err)
 	}
@@ -311,8 +311,8 @@ func splitIntoMultiBatch(messages [][]byte, signatures [][]byte, signer []byte, 
 	return res, nil
 }
 
-func (pr *Prover) CheckRefreshRequired(counterparty core.ChainInfoICS02Querier) (bool, error) {
-	return pr.originProver.CheckRefreshRequired(counterparty)
+func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.ChainInfoICS02Querier) (bool, error) {
+	return pr.originProver.CheckRefreshRequired(context.TODO(), counterparty)
 }
 
 func (pr *Prover) ProveState(ctx core.QueryContext, path string, value []byte) ([]byte, clienttypes.Height, error) {

--- a/relay/restore.go
+++ b/relay/restore.go
@@ -23,7 +23,7 @@ func (pr *Prover) restoreELC(ctx context.Context, counterparty core.FinalityAwar
 		return fmt.Errorf("client '%v' already exists", elcClientID)
 	}
 
-	cplatestHeight, err := counterparty.LatestHeight()
+	cplatestHeight, err := counterparty.LatestHeight(context.TODO())
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (pr *Prover) restoreELC(ctx context.Context, counterparty core.FinalityAwar
 		return fmt.Errorf("allowed advisory ids mismatch: expected %v, but got %v", pr.config.AllowedAdvisoryIds, clientState.AllowedAdvisoryIds)
 	}
 
-	originClientState, originConsensusState, err := pr.originProver.CreateInitialLightClientState(clientState.LatestHeight)
+	originClientState, originConsensusState, err := pr.originProver.CreateInitialLightClientState(context.TODO(), clientState.LatestHeight)
 	if err != nil {
 		return fmt.Errorf("failed to create initial light client state: height=%v %w", clientState.LatestHeight, err)
 	}

--- a/relay/signers/raw/signer.go
+++ b/relay/signers/raw/signer.go
@@ -1,6 +1,7 @@
 package raw
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 
@@ -20,11 +21,11 @@ func NewSigner(privKey *ecdsa.PrivateKey) *Signer {
 	}
 }
 
-func (s *Signer) GetPublicKey() ([]byte, error) {
+func (s *Signer) GetPublicKey(_ context.Context) ([]byte, error) {
 	return crypto.CompressPubkey(&s.privKey.PublicKey), nil
 }
 
-func (s *Signer) Sign(digest []byte) ([]byte, error) {
+func (s *Signer) Sign(_ context.Context, digest []byte) ([]byte, error) {
 	sig, err := crypto.Sign(digest, s.privKey)
 	if err != nil {
 		return nil, fmt.Errorf("failed to sign tx: %v", err)


### PR DESCRIPTION
This PR is part of the second phase of OpenTelemetry integration.
For more details, refer to https://github.com/hyperledger-labs/yui-relayer/pull/153.