### PR TITLE
Use context appropriately

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ lcp-go includes the followings:
 
 - [lcp v0.2.13-rc.0](https://github.com/datachainlab/lcp/releases/tag/v0.2.13-rc.0)
 - [ibc-go v8.2](https://github.com/cosmos/ibc-go/releases/tag/v8.2.0)
-- [yui-relayer v0.5.11](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.5.11)
+- [yui-relayer v0.5.12](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.5.12)
 
 ## How to run tests
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ethereum/go-ethereum v1.14.12
 	github.com/gogo/protobuf v1.3.2
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
-	github.com/hyperledger-labs/yui-relayer v0.5.11
+	github.com/hyperledger-labs/yui-relayer v0.5.12
 	github.com/oasisprotocol/oasis-core/go v0.2403.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ github.com/huandu/go-assert v1.1.5/go.mod h1:yOLvuqZwmcHIC5rIzrBhT7D3Q9c3GFnd0Jr
 github.com/huandu/skiplist v1.2.0 h1:gox56QD77HzSC0w+Ws3MH3iie755GBJU1OER3h5VsYw=
 github.com/huandu/skiplist v1.2.0/go.mod h1:7v3iFjLcSAzO4fN5B8dvebvo/qsfumiLiDXMrPiHF9w=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
-github.com/hyperledger-labs/yui-relayer v0.5.11 h1:tBDWJa96jQhxL9zLDbB94VvSgw0f8Xk9tqPuKMT3ARw=
-github.com/hyperledger-labs/yui-relayer v0.5.11/go.mod h1:kJvSmuagdDsSlvbnHtEHbhmkUlAS43/ArLDwukOKSlo=
+github.com/hyperledger-labs/yui-relayer v0.5.12 h1:Mp3iunlbDI4LjjUyPm9ZQgGxkzRfovwxFAl5K2Y+kTE=
+github.com/hyperledger-labs/yui-relayer v0.5.12/go.mod h1:kJvSmuagdDsSlvbnHtEHbhmkUlAS43/ArLDwukOKSlo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/relay/cmd.go
+++ b/relay/cmd.go
@@ -358,7 +358,7 @@ func updateOperatorsCmd(ctx *config.Context) *cobra.Command {
 				Denominator: viper.GetUint64(flagThresholdDenominator),
 			}
 			nonce := viper.GetUint64(flagNonce)
-			return prover.updateOperators(counterparty, nonce, newOpAddrs, threshold)
+			return prover.updateOperators(context.TODO(), counterparty, nonce, newOpAddrs, threshold)
 		},
 	}
 	cmd = thresholdFlag(

--- a/relay/cmd.go
+++ b/relay/cmd.go
@@ -103,7 +103,7 @@ func updateEnclaveKeyCmd(ctx *config.Context) *cobra.Command {
 				verifier = c[src]
 			}
 			prover := target.Prover.(*Prover)
-			return prover.UpdateEKIfNeeded(context.TODO(), verifier)
+			return prover.UpdateEKIIfNeeded(context.TODO(), verifier)
 		},
 	}
 	return srcFlag(cmd)

--- a/relay/cmd.go
+++ b/relay/cmd.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -66,7 +65,7 @@ func availableEnclaveKeysCmd(ctx *config.Context) *cobra.Command {
 				target = c[dst]
 			}
 			prover := target.Prover.(*Prover)
-			ekis, err := prover.doAvailableEnclaveKeys(context.TODO())
+			ekis, err := prover.doAvailableEnclaveKeys(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -103,7 +102,7 @@ func updateEnclaveKeyCmd(ctx *config.Context) *cobra.Command {
 				verifier = c[src]
 			}
 			prover := target.Prover.(*Prover)
-			return prover.UpdateEKIIfNeeded(context.TODO(), verifier)
+			return prover.UpdateEKIIfNeeded(cmd.Context(), verifier)
 		},
 	}
 	return srcFlag(cmd)
@@ -135,7 +134,7 @@ func activateClientCmd(ctx *config.Context) *cobra.Command {
 				pathEnd = path.Src
 				target, counterparty = c[dst], c[src]
 			}
-			return activateClient(context.TODO(), pathEnd, target, counterparty, viper.GetDuration(flagRetryInterval), viper.GetUint(flagRetryMaxAttempts))
+			return activateClient(cmd.Context(), pathEnd, target, counterparty, viper.GetDuration(flagRetryInterval), viper.GetUint(flagRetryMaxAttempts))
 		},
 	}
 	return retryMaxAttemptsFlag(retryIntervalFlag(srcFlag(cmd)))
@@ -164,7 +163,7 @@ func createELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doCreateELC(context.TODO(), elcClientID, viper.GetUint64(flagHeight))
+			out, err := prover.doCreateELC(cmd.Context(), elcClientID, viper.GetUint64(flagHeight))
 			if err != nil {
 				return err
 			}
@@ -206,7 +205,7 @@ func updateELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doUpdateELC(context.TODO(), elcClientID)
+			out, err := prover.doUpdateELC(cmd.Context(), elcClientID)
 			if err != nil {
 				return err
 			}
@@ -244,7 +243,7 @@ func queryELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doQueryELC(context.TODO(), elcClientID)
+			out, err := prover.doQueryELC(cmd.Context(), elcClientID)
 			if err != nil {
 				return err
 			}
@@ -287,7 +286,7 @@ func restoreELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			return prover.restoreELC(context.TODO(), verifier, elcClientID, viper.GetUint64(flagHeight))
+			return prover.restoreELC(cmd.Context(), verifier, elcClientID, viper.GetUint64(flagHeight))
 		},
 	}
 	return elcClientIDFlag(heightFlag(srcFlag(cmd)))
@@ -310,7 +309,7 @@ func removeEnclaveKeyInfoCmd(ctx *config.Context) *cobra.Command {
 				target = c[dst]
 			}
 			prover := target.Prover.(*Prover)
-			return prover.removeEnclaveKeyInfos(context.TODO())
+			return prover.removeEnclaveKeyInfos(cmd.Context())
 		},
 	}
 	return srcFlag(cmd)
@@ -358,7 +357,7 @@ func updateOperatorsCmd(ctx *config.Context) *cobra.Command {
 				Denominator: viper.GetUint64(flagThresholdDenominator),
 			}
 			nonce := viper.GetUint64(flagNonce)
-			return prover.updateOperators(context.TODO(), counterparty, nonce, newOpAddrs, threshold)
+			return prover.updateOperators(cmd.Context(), counterparty, nonce, newOpAddrs, threshold)
 		},
 	}
 	cmd = thresholdFlag(

--- a/relay/cmd.go
+++ b/relay/cmd.go
@@ -135,7 +135,7 @@ func activateClientCmd(ctx *config.Context) *cobra.Command {
 				pathEnd = path.Src
 				target, counterparty = c[dst], c[src]
 			}
-			return activateClient(pathEnd, target, counterparty, viper.GetDuration(flagRetryInterval), viper.GetUint(flagRetryMaxAttempts))
+			return activateClient(context.TODO(), pathEnd, target, counterparty, viper.GetDuration(flagRetryInterval), viper.GetUint(flagRetryMaxAttempts))
 		},
 	}
 	return retryMaxAttemptsFlag(retryIntervalFlag(srcFlag(cmd)))
@@ -164,7 +164,7 @@ func createELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doCreateELC(elcClientID, viper.GetUint64(flagHeight))
+			out, err := prover.doCreateELC(context.TODO(), elcClientID, viper.GetUint64(flagHeight))
 			if err != nil {
 				return err
 			}
@@ -206,7 +206,7 @@ func updateELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doUpdateELC(elcClientID)
+			out, err := prover.doUpdateELC(context.TODO(), elcClientID)
 			if err != nil {
 				return err
 			}
@@ -244,7 +244,7 @@ func queryELCCmd(ctx *config.Context) *cobra.Command {
 			} else {
 				elcClientID = prover.config.ElcClientId
 			}
-			out, err := prover.doQueryELC(elcClientID)
+			out, err := prover.doQueryELC(context.TODO(), elcClientID)
 			if err != nil {
 				return err
 			}

--- a/relay/config.go
+++ b/relay/config.go
@@ -148,7 +148,7 @@ func (pc ProverConfig) Validate() error {
 		if err != nil {
 			return fmt.Errorf("failed to build the OperatorSigner: %v", err)
 		}
-		addr, err := NewEIP712Signer(signer).GetSignerAddress(context.TODO())
+		addr, err := NewEIP712Signer(signer).GetSignerAddress(context.Background())
 		if err != nil {
 			return fmt.Errorf("failed to get the OperatorSigner's address: %v", err)
 		}

--- a/relay/config.go
+++ b/relay/config.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -147,7 +148,7 @@ func (pc ProverConfig) Validate() error {
 		if err != nil {
 			return fmt.Errorf("failed to build the OperatorSigner: %v", err)
 		}
-		addr, err := NewEIP712Signer(signer).GetSignerAddress()
+		addr, err := NewEIP712Signer(signer).GetSignerAddress(context.TODO())
 		if err != nil {
 			return fmt.Errorf("failed to get the OperatorSigner's address: %v", err)
 		}

--- a/relay/lcp.go
+++ b/relay/lcp.go
@@ -44,7 +44,7 @@ type EIP712DomainParams struct {
 }
 
 // UpdateEKIIfNeeded checks if the enclave key needs to be updated
-func (pr *Prover) UpdateEKIfNeeded(ctx context.Context, counterparty core.FinalityAwareChain) error {
+func (pr *Prover) UpdateEKIIfNeeded(ctx context.Context, counterparty core.FinalityAwareChain) error {
 	updateNeeded, err := pr.loadEKIAndCheckUpdateNeeded(ctx, counterparty)
 	if err != nil {
 		return fmt.Errorf("failed to call loadEKIAndCheckUpdateNeeded: %w", err)
@@ -896,7 +896,7 @@ func (pr *Prover) createELC(elcClientID string, height ibcexported.Height) (*elc
 
 func activateClient(pathEnd *core.PathEnd, src, dst *core.ProvableChain, retryInterval time.Duration, retryMaxAttempts uint) error {
 	srcProver := src.Prover.(*Prover)
-	if err := srcProver.UpdateEKIfNeeded(context.TODO(), dst); err != nil {
+	if err := srcProver.UpdateEKIIfNeeded(context.TODO(), dst); err != nil {
 		return err
 	}
 

--- a/relay/lcp.go
+++ b/relay/lcp.go
@@ -69,12 +69,12 @@ func (pr *Prover) UpdateEKIIfNeeded(ctx context.Context, counterparty core.Final
 
 	pr.getLogger().Info("try to register a new enclave key", "eki", eki)
 
-	msgID, err := pr.registerEnclaveKey(counterparty, eki)
+	msgID, err := pr.registerEnclaveKey(ctx, counterparty, eki)
 	if err != nil {
 		return fmt.Errorf("failed to call registerEnclaveKey: %w", err)
 	}
 	pr.getLogger().Info("registered a new enclave key", "enclave_key", eki.GetEnclaveKeyAddress(), "msg_id", msgID.String())
-	finalized, success, err := pr.checkMsgStatus(counterparty, msgID)
+	finalized, success, err := pr.checkMsgStatus(ctx, counterparty, msgID)
 	if err != nil {
 		return fmt.Errorf("failed to call checkMsgStatus: %w", err)
 	} else if !success {
@@ -137,17 +137,17 @@ func (pr *Prover) checkEKIUpdateNeeded(ctx context.Context, now time.Time, eki *
 	return false
 }
 
-// isFinalizedMsg checks if the given msg is finalized in the origin chain
+// checkMsgStatus checks if the given msg is finalized in the origin chain
 // and returns (finalized, success, error)
 // finalized: true if the msg is finalized
 // success: true if the msg is successfully executed in the origin chain
 // error: non-nil if the msg may not exist in the origin chain
-func (pr *Prover) checkMsgStatus(counterparty core.FinalityAwareChain, msgID core.MsgID) (bool, bool, error) {
-	lfHeader, err := counterparty.GetLatestFinalizedHeader(context.TODO())
+func (pr *Prover) checkMsgStatus(ctx context.Context, counterparty core.FinalityAwareChain, msgID core.MsgID) (bool, bool, error) {
+	lfHeader, err := counterparty.GetLatestFinalizedHeader(ctx)
 	if err != nil {
 		return false, false, err
 	}
-	msgRes, err := counterparty.GetMsgResult(context.TODO(), msgID)
+	msgRes, err := counterparty.GetMsgResult(ctx, msgID)
 	if err != nil {
 		return false, false, err
 	} else if ok, failureReason := msgRes.Status(); !ok {
@@ -202,7 +202,7 @@ func (pr *Prover) loadEKIAndCheckUpdateNeeded(ctx context.Context, counterparty 
 
 	pr.getLogger().Info("active enclave key is unfinalized")
 
-	if _, err := counterparty.GetMsgResult(context.TODO(), pr.unfinalizedMsgID); err != nil {
+	if _, err := counterparty.GetMsgResult(ctx, pr.unfinalizedMsgID); err != nil {
 		// err means that the msg is not included in the latest block
 		pr.getLogger().Info("the msg is not included in the latest block", "msg_id", pr.unfinalizedMsgID.String(), "error", err)
 		if err := pr.removeUnfinalizedEnclaveKeyInfo(ctx); err != nil {
@@ -211,7 +211,7 @@ func (pr *Prover) loadEKIAndCheckUpdateNeeded(ctx context.Context, counterparty 
 		return true, nil
 	}
 
-	finalized, success, err := pr.checkMsgStatus(counterparty, pr.unfinalizedMsgID)
+	finalized, success, err := pr.checkMsgStatus(ctx, counterparty, pr.unfinalizedMsgID)
 	pr.getLogger().Info("check the unfinalized msg status", "msg_id", pr.unfinalizedMsgID.String(), "finalized", finalized, "success", success, "error", err)
 	if err != nil {
 		return false, err
@@ -367,18 +367,18 @@ func (pr *Prover) validateAdvisoryIDs(ids []string) bool {
 	return targetSet.Difference(allowedSet).Cardinality() == 0
 }
 
-func (pr *Prover) updateELC(elcClientID string, includeState bool) ([]*elc.MsgUpdateClientResponse, error) {
+func (pr *Prover) updateELC(ctx context.Context, elcClientID string, includeState bool) ([]*elc.MsgUpdateClientResponse, error) {
 
 	// 1. check if the latest height of the client is less than the given height
 
-	res, err := pr.lcpServiceClient.Client(context.TODO(), &elc.QueryClientRequest{ClientId: elcClientID})
+	res, err := pr.lcpServiceClient.Client(ctx, &elc.QueryClientRequest{ClientId: elcClientID})
 	if err != nil {
 		return nil, err
 	}
 	if !res.Found {
 		return nil, fmt.Errorf("client not found: client_id=%v", elcClientID)
 	}
-	latestHeader, err := pr.originProver.GetLatestFinalizedHeader(context.TODO())
+	latestHeader, err := pr.originProver.GetLatestFinalizedHeader(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +396,7 @@ func (pr *Prover) updateELC(elcClientID string, includeState bool) ([]*elc.MsgUp
 
 	// 2. query the header from the upstream chain
 
-	headers, err := pr.originProver.SetupHeadersForUpdate(context.TODO(), NewLCPQuerier(pr.lcpServiceClient, elcClientID), latestHeader)
+	headers, err := pr.originProver.SetupHeadersForUpdate(ctx, NewLCPQuerier(pr.lcpServiceClient, elcClientID), latestHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -411,7 +411,7 @@ func (pr *Prover) updateELC(elcClientID string, includeState bool) ([]*elc.MsgUp
 		if err != nil {
 			return nil, err
 		}
-		res, err := pr.lcpServiceClient.UpdateClient(context.TODO(), &elc.MsgUpdateClient{
+		res, err := pr.lcpServiceClient.UpdateClient(ctx, &elc.MsgUpdateClient{
 			ClientId:     elcClientID,
 			Header:       anyHeader,
 			IncludeState: includeState,
@@ -426,12 +426,12 @@ func (pr *Prover) updateELC(elcClientID string, includeState bool) ([]*elc.MsgUp
 	return responses, nil
 }
 
-func (pr *Prover) registerEnclaveKey(counterparty core.FinalityAwareChain, eki *enclave.EnclaveKeyInfo) (core.MsgID, error) {
+func (pr *Prover) registerEnclaveKey(ctx context.Context, counterparty core.FinalityAwareChain, eki *enclave.EnclaveKeyInfo) (core.MsgID, error) {
 	switch v := eki.KeyInfo.(type) {
 	case *enclave.EnclaveKeyInfo_Ias:
-		return pr.registerIASEnclaveKey(counterparty, v.Ias)
+		return pr.registerIASEnclaveKey(ctx, counterparty, v.Ias)
 	case *enclave.EnclaveKeyInfo_Zkdcap:
-		return pr.registerZKDCAPEnclaveKey(counterparty, v.Zkdcap)
+		return pr.registerZKDCAPEnclaveKey(ctx, counterparty, v.Zkdcap)
 	case *enclave.EnclaveKeyInfo_Dcap:
 		return nil, errors.New("DCAP enclave key is not supported yet")
 	default:
@@ -439,7 +439,7 @@ func (pr *Prover) registerEnclaveKey(counterparty core.FinalityAwareChain, eki *
 	}
 }
 
-func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IASEnclaveKeyInfo) (core.MsgID, error) {
+func (pr *Prover) registerIASEnclaveKey(ctx context.Context, counterparty core.Chain, eki *enclave.IASEnclaveKeyInfo) (core.MsgID, error) {
 	clientLogger := pr.getClientLogger(pr.originChain.Path().ClientID)
 	if err := ias.VerifyReport([]byte(eki.Report), eki.Signature, eki.SigningCert, time.Now()); err != nil {
 		return nil, fmt.Errorf("failed to verify AVR signature: %w", err)
@@ -463,11 +463,11 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 		SigningCert:       eki.SigningCert,
 		OperatorSignature: nil,
 	}
-	cplatestHeight, err := counterparty.LatestHeight(context.TODO())
+	cplatestHeight, err := counterparty.LatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
-	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(context.TODO(), cplatestHeight))
+	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(ctx, cplatestHeight))
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 		return nil, fmt.Errorf("MRENCLAVE mismatch: expected 0x%x, but got 0x%x", clientState.Mrenclave, quote.Report.MRENCLAVE[:])
 	}
 	if pr.IsOperatorEnabled() {
-		operator, err := pr.eip712Signer.GetSignerAddress(context.TODO())
+		operator, err := pr.eip712Signer.GetSignerAddress(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -497,7 +497,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 		if err != nil {
 			return nil, err
 		}
-		sig, err := pr.eip712Signer.Sign(context.TODO(), commitment)
+		sig, err := pr.eip712Signer.Sign(ctx, commitment)
 		if err != nil {
 			return nil, err
 		}
@@ -512,7 +512,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 	if err != nil {
 		return nil, err
 	}
-	ids, err := counterparty.SendMsgs(context.TODO(), []sdk.Msg{msg})
+	ids, err := counterparty.SendMsgs(ctx, []sdk.Msg{msg})
 	if err != nil {
 		return nil, err
 	}
@@ -522,7 +522,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 	return ids[0], nil
 }
 
-func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave.ZKDCAPEnclaveKeyInfo) (core.MsgID, error) {
+func (pr *Prover) registerZKDCAPEnclaveKey(ctx context.Context, counterparty core.Chain, eki *enclave.ZKDCAPEnclaveKeyInfo) (core.MsgID, error) {
 	clientLogger := pr.getClientLogger(pr.originChain.Path().ClientID)
 	zkp := eki.Zkp.GetRisc0()
 	if zkp == nil {
@@ -551,11 +551,11 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 	if err != nil {
 		return nil, err
 	}
-	cplatestHeight, err := counterparty.LatestHeight(context.TODO())
+	cplatestHeight, err := counterparty.LatestHeight(ctx)
 	if err != nil {
 		return nil, err
 	}
-	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(context.TODO(), cplatestHeight))
+	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(ctx, cplatestHeight))
 	if err != nil {
 		return nil, err
 	}
@@ -586,7 +586,7 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 		return nil, fmt.Errorf("failed to verify RISC0 ZKDCAP proof: %w", err)
 	}
 	if pr.IsOperatorEnabled() {
-		operator, err := pr.eip712Signer.GetSignerAddress(context.TODO())
+		operator, err := pr.eip712Signer.GetSignerAddress(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -600,7 +600,7 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 		if err != nil {
 			return nil, err
 		}
-		sig, err := pr.eip712Signer.Sign(context.TODO(), commitment)
+		sig, err := pr.eip712Signer.Sign(ctx, commitment)
 		if err != nil {
 			return nil, err
 		}
@@ -615,7 +615,7 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 	if err != nil {
 		return nil, err
 	}
-	ids, err := counterparty.SendMsgs(context.TODO(), []sdk.Msg{msg})
+	ids, err := counterparty.SendMsgs(ctx, []sdk.Msg{msg})
 	if err != nil {
 		return nil, err
 	}
@@ -720,8 +720,8 @@ type CreateELCResult struct {
 }
 
 // height: 0 means the latest height
-func (pr *Prover) doCreateELC(elcClientID string, height uint64) (*CreateELCResult, error) {
-	header, err := pr.originProver.GetLatestFinalizedHeader(context.TODO())
+func (pr *Prover) doCreateELC(ctx context.Context, elcClientID string, height uint64) (*CreateELCResult, error) {
+	header, err := pr.originProver.GetLatestFinalizedHeader(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -733,7 +733,7 @@ func (pr *Prover) doCreateELC(elcClientID string, height uint64) (*CreateELCResu
 	}
 	h := clienttypes.NewHeight(latestHeight.GetRevisionNumber(), height)
 	pr.getLogger().Info("try to create ELC client", "elc_client_id", elcClientID, "height", h)
-	res, err := pr.createELC(elcClientID, h)
+	res, err := pr.createELC(ctx, elcClientID, h)
 	if err != nil {
 		return nil, err
 	} else if res == nil {
@@ -761,9 +761,9 @@ type UpdateELCResult struct {
 	Messages []*lcptypes.UpdateStateProxyMessage `json:"messages"`
 }
 
-func (pr *Prover) doUpdateELC(elcClientID string) (*UpdateELCResult, error) {
+func (pr *Prover) doUpdateELC(ctx context.Context, elcClientID string) (*UpdateELCResult, error) {
 	if pr.activeEnclaveKey == nil {
-		eki, err := pr.selectNewEnclaveKey(context.TODO())
+		eki, err := pr.selectNewEnclaveKey(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -771,7 +771,7 @@ func (pr *Prover) doUpdateELC(elcClientID string) (*UpdateELCResult, error) {
 		pr.activeEnclaveKey = eki
 	}
 	pr.getLogger().Info("try to update the ELC client", "elc_client_id", elcClientID)
-	updates, err := pr.updateELC(elcClientID, false)
+	updates, err := pr.updateELC(ctx, elcClientID, false)
 	if err != nil {
 		return nil, err
 	}
@@ -818,8 +818,8 @@ type Any struct {
 	Value   []byte `json:"value"`
 }
 
-func (pr *Prover) doQueryELC(elcClientID string) (*QueryELCResult, error) {
-	r, err := pr.lcpServiceClient.Client(context.TODO(), &elc.QueryClientRequest{ClientId: elcClientID})
+func (pr *Prover) doQueryELC(ctx context.Context, elcClientID string) (*QueryELCResult, error) {
+	r, err := pr.lcpServiceClient.Client(ctx, &elc.QueryClientRequest{ClientId: elcClientID})
 	if err != nil {
 		return nil, err
 	} else if !r.Found {
@@ -854,19 +854,19 @@ func (pr *Prover) doQueryELC(elcClientID string) (*QueryELCResult, error) {
 	return &result, nil
 }
 
-func (pr *Prover) createELC(elcClientID string, height ibcexported.Height) (*elc.MsgCreateClientResponse, error) {
-	res, err := pr.lcpServiceClient.Client(context.TODO(), &elc.QueryClientRequest{ClientId: elcClientID})
+func (pr *Prover) createELC(ctx context.Context, elcClientID string, height ibcexported.Height) (*elc.MsgCreateClientResponse, error) {
+	res, err := pr.lcpServiceClient.Client(ctx, &elc.QueryClientRequest{ClientId: elcClientID})
 	if err != nil {
 		return nil, err
 	} else if res.Found {
 		return nil, nil
 	}
 	// NOTE: Query the LCP for available keys, but no need to register it into on-chain here
-	tmpEKI, err := pr.selectNewEnclaveKey(context.TODO())
+	tmpEKI, err := pr.selectNewEnclaveKey(ctx)
 	if err != nil {
 		return nil, err
 	}
-	originClientState, originConsensusState, err := pr.originProver.CreateInitialLightClientState(context.TODO(), height)
+	originClientState, originConsensusState, err := pr.originProver.CreateInitialLightClientState(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -878,7 +878,7 @@ func (pr *Prover) createELC(elcClientID string, height ibcexported.Height) (*elc
 	if err != nil {
 		return nil, err
 	}
-	return pr.lcpServiceClient.CreateClient(context.TODO(), &elc.MsgCreateClient{
+	return pr.lcpServiceClient.CreateClient(ctx, &elc.MsgCreateClient{
 		ClientId:       elcClientID,
 		ClientState:    anyOriginClientState,
 		ConsensusState: anyOriginConsensusState,
@@ -886,9 +886,9 @@ func (pr *Prover) createELC(elcClientID string, height ibcexported.Height) (*elc
 	})
 }
 
-func activateClient(pathEnd *core.PathEnd, src, dst *core.ProvableChain, retryInterval time.Duration, retryMaxAttempts uint) error {
+func activateClient(ctx context.Context, pathEnd *core.PathEnd, src, dst *core.ProvableChain, retryInterval time.Duration, retryMaxAttempts uint) error {
 	srcProver := src.Prover.(*Prover)
-	if err := srcProver.UpdateEKIIfNeeded(context.TODO(), dst); err != nil {
+	if err := srcProver.UpdateEKIIfNeeded(ctx, dst); err != nil {
 		return err
 	}
 
@@ -898,14 +898,14 @@ func activateClient(pathEnd *core.PathEnd, src, dst *core.ProvableChain, retryIn
 	var updates []*elc.MsgUpdateClientResponse
 	if err := retry.Do(func() error {
 		var err error
-		updates, err = srcProver.updateELC(srcProver.config.ElcClientId, true)
+		updates, err = srcProver.updateELC(ctx, srcProver.config.ElcClientId, true)
 		if err != nil {
 			return err
 		} else if len(updates) == 0 {
 			return fmt.Errorf("no available updates: elc_client_id=%v", srcProver.config.ElcClientId)
 		}
 		return nil
-	}, retry.Attempts(retryMaxAttempts+1), retry.Delay(retryInterval)); err != nil {
+	}, retry.Attempts(retryMaxAttempts+1), retry.Delay(retryInterval), retry.Context(ctx)); err != nil {
 		return err
 	}
 
@@ -932,7 +932,7 @@ func activateClient(pathEnd *core.PathEnd, src, dst *core.ProvableChain, retryIn
 	}
 
 	// 3. Submit the msgs to the LCP Client
-	if _, err := dst.SendMsgs(context.TODO(), msgs); err != nil {
+	if _, err := dst.SendMsgs(ctx, msgs); err != nil {
 		return err
 	}
 	return nil

--- a/relay/lcp.go
+++ b/relay/lcp.go
@@ -482,7 +482,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 		return nil, fmt.Errorf("MRENCLAVE mismatch: expected 0x%x, but got 0x%x", clientState.Mrenclave, quote.Report.MRENCLAVE[:])
 	}
 	if pr.IsOperatorEnabled() {
-		operator, err := pr.eip712Signer.GetSignerAddress()
+		operator, err := pr.eip712Signer.GetSignerAddress(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -496,7 +496,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 		if err != nil {
 			return nil, err
 		}
-		sig, err := pr.eip712Signer.Sign(commitment)
+		sig, err := pr.eip712Signer.Sign(context.TODO(), commitment)
 		if err != nil {
 			return nil, err
 		}
@@ -585,7 +585,7 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 		return nil, fmt.Errorf("failed to verify RISC0 ZKDCAP proof: %w", err)
 	}
 	if pr.IsOperatorEnabled() {
-		operator, err := pr.eip712Signer.GetSignerAddress()
+		operator, err := pr.eip712Signer.GetSignerAddress(context.TODO())
 		if err != nil {
 			return nil, err
 		}
@@ -599,7 +599,7 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 		if err != nil {
 			return nil, err
 		}
-		sig, err := pr.eip712Signer.Sign(commitment)
+		sig, err := pr.eip712Signer.Sign(context.TODO(), commitment)
 		if err != nil {
 			return nil, err
 		}

--- a/relay/lcp.go
+++ b/relay/lcp.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/avast/retry-go"
@@ -486,7 +487,7 @@ func (pr *Prover) registerIASEnclaveKey(counterparty core.Chain, eki *enclave.IA
 		if err != nil {
 			return nil, err
 		}
-		if operators := clientState.GetOperators(); !containsOperator(operators, operator) {
+		if operators := clientState.GetOperators(); !slices.Contains(operators, operator) {
 			return nil, fmt.Errorf("the operator is not included in the operators: client_state.operators=%v operator=%v", operators, operator)
 		}
 		if expectedOperator != [20]byte{} && operator != expectedOperator {
@@ -589,7 +590,7 @@ func (pr *Prover) registerZKDCAPEnclaveKey(counterparty core.Chain, eki *enclave
 		if err != nil {
 			return nil, err
 		}
-		if operators := clientState.GetOperators(); !containsOperator(operators, operator) {
+		if operators := clientState.GetOperators(); !slices.Contains(operators, operator) {
 			return nil, fmt.Errorf("the operator is not included in the operators: client_state.operators=%v operator=%v", operators, operator)
 		}
 		if expectedOperator != [20]byte{} && operator != expectedOperator {
@@ -796,15 +797,6 @@ func (pr *Prover) doUpdateELC(elcClientID string) (*UpdateELCResult, error) {
 	return &UpdateELCResult{
 		Messages: msgs,
 	}, nil
-}
-
-func containsOperator(operators []common.Address, operator common.Address) bool {
-	for _, op := range operators {
-		if op == operator {
-			return true
-		}
-	}
-	return false
 }
 
 type QueryELCResult struct {

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -151,7 +151,7 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 
 	consensusState := &lcptypes.ConsensusState{}
 
-	if res, err := pr.createELC(pr.config.ElcClientId, height); err != nil {
+	if res, err := pr.createELC(context.TODO(), pr.config.ElcClientId, height); err != nil {
 		return nil, nil, fmt.Errorf("failed to create ELC: %w", err)
 	} else if res == nil {
 		pr.getLogger().Info("no need to create ELC", "elc_client_id", pr.config.ElcClientId)

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -76,7 +76,7 @@ func (pr *Prover) GetOriginProver() core.Prover {
 func (pr *Prover) Init(homePath string, timeout time.Duration, codec codec.ProtoCodecMarshaler, debug bool) error {
 	pr.homePath = homePath
 	pr.codec = codec
-	res, err := pr.lcpServiceClient.EnclaveInfo(context.TODO(), &enclave.QueryEnclaveInfoRequest{})
+	res, err := pr.lcpServiceClient.EnclaveInfo(context.Background(), &enclave.QueryEnclaveInfoRequest{})
 	if err != nil {
 		return fmt.Errorf("failed to get enclave info: %w", err)
 	}
@@ -151,7 +151,7 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 
 	consensusState := &lcptypes.ConsensusState{}
 
-	if res, err := pr.createELC(context.TODO(), pr.config.ElcClientId, height); err != nil {
+	if res, err := pr.createELC(ctx, pr.config.ElcClientId, height); err != nil {
 		return nil, nil, fmt.Errorf("failed to create ELC: %w", err)
 	} else if res == nil {
 		pr.getLogger().Info("no need to create ELC", "elc_client_id", pr.config.ElcClientId)
@@ -164,18 +164,18 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 // GetLatestFinalizedHeader returns the latest finalized header on this chain
 // The returned header is expected to be the latest one of headers that can be verified by the light client
 func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, error) {
-	return pr.originProver.GetLatestFinalizedHeader(context.TODO())
+	return pr.originProver.GetLatestFinalizedHeader(ctx)
 }
 
-// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterpaty chain
+// SetupHeadersForUpdate returns the finalized header and any intermediate headers needed to apply it to the client on the counterparty chain
 // The order of the returned header slice should be as: [<intermediate headers>..., <update header>]
 // if the header slice's length == nil and err == nil, the relayer should skip the update-client
 func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
-	if err := pr.UpdateEKIIfNeeded(context.TODO(), dstChain); err != nil {
+	if err := pr.UpdateEKIIfNeeded(ctx, dstChain); err != nil {
 		return nil, err
 	}
 
-	headers, err := pr.originProver.SetupHeadersForUpdate(context.TODO(), dstChain, latestFinalizedHeader)
+	headers, err := pr.originProver.SetupHeadersForUpdate(ctx, dstChain, latestFinalizedHeader)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup headers for update: header=%v %w", latestFinalizedHeader, err)
 	}
@@ -197,7 +197,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.Final
 			IncludeState: false,
 			Signer:       pr.activeEnclaveKey.GetEnclaveKeyAddress().Bytes(),
 		}
-		res, err := pr.lcpServiceClient.UpdateClient(context.TODO(), &m)
+		res, err := pr.lcpServiceClient.UpdateClient(ctx, &m)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update ELC: i=%v elc_client_id=%v msg=%v %w", i, pr.config.ElcClientId, m, err)
 		}
@@ -213,7 +213,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.Final
 	// NOTE: assume that the messages length and the signatures length are the same
 	if pr.config.MessageAggregation {
 		pr.getLogger().Info("aggregate messages", "num_messages", len(messages))
-		update, err := aggregateMessages(pr.getLogger(), pr.config.GetMessageAggregationBatchSize(), pr.lcpServiceClient.AggregateMessages, messages, signatures, pr.activeEnclaveKey.GetEnclaveKeyAddress().Bytes())
+		update, err := aggregateMessages(ctx, pr.getLogger(), pr.config.GetMessageAggregationBatchSize(), pr.lcpServiceClient.AggregateMessages, messages, signatures, pr.activeEnclaveKey.GetEnclaveKeyAddress().Bytes())
 		if err != nil {
 			return nil, err
 		}
@@ -233,6 +233,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.Final
 type MessageAggregator func(ctx context.Context, in *elc.MsgAggregateMessages, opts ...grpc.CallOption) (*elc.MsgAggregateMessagesResponse, error)
 
 func aggregateMessages(
+	ctx context.Context,
 	logger *log.RelayLogger,
 	batchSize uint64,
 	messageAggregator MessageAggregator,
@@ -264,7 +265,7 @@ func aggregateMessages(
 					Messages:   batches[0].Messages,
 					Signatures: batches[0].Signatures,
 				}
-				resp, err := messageAggregator(context.TODO(), &m)
+				resp, err := messageAggregator(ctx, &m)
 				if err != nil {
 					return nil, fmt.Errorf("failed to aggregate messages: msg=%v %w", m, err)
 				}
@@ -291,7 +292,7 @@ func aggregateMessages(
 					Messages:   b.Messages,
 					Signatures: b.Signatures,
 				}
-				resp, err := messageAggregator(context.TODO(), &m)
+				resp, err := messageAggregator(ctx, &m)
 				if err != nil {
 					return nil, fmt.Errorf("failed to aggregate messages: batch_index=%v msg=%v %w", i, m, err)
 				}
@@ -332,7 +333,7 @@ func splitIntoMultiBatch(messages [][]byte, signatures [][]byte, signer []byte, 
 }
 
 func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.ChainInfoICS02Querier) (bool, error) {
-	return pr.originProver.CheckRefreshRequired(context.TODO(), counterparty)
+	return pr.originProver.CheckRefreshRequired(ctx, counterparty)
 }
 
 func (pr *Prover) ProveState(ctx core.QueryContext, path string, value []byte) ([]byte, clienttypes.Height, error) {

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -171,7 +171,7 @@ func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (core.Header, er
 // The order of the returned header slice should be as: [<intermediate headers>..., <update header>]
 // if the header slice's length == nil and err == nil, the relayer should skip the update-client
 func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, dstChain core.FinalityAwareChain, latestFinalizedHeader core.Header) ([]core.Header, error) {
-	if err := pr.UpdateEKIfNeeded(context.TODO(), dstChain); err != nil {
+	if err := pr.UpdateEKIIfNeeded(context.TODO(), dstChain); err != nil {
 		return nil, err
 	}
 

--- a/relay/prover_test.go
+++ b/relay/prover_test.go
@@ -177,7 +177,7 @@ func TestAggregateMessages(t *testing.T) {
 	for i, c := range cases {
 		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
 			require := require.New(t)
-			res, err := aggregateMessages(logger, c.BatchSize, mockMessageAggregator, c.Messages, c.Signatures, c.Signer)
+			res, err := aggregateMessages(context.Background(), logger, c.BatchSize, mockMessageAggregator, c.Messages, c.Signatures, c.Signer)
 			if c.Error {
 				require.Error(err)
 				return

--- a/relay/restore.go
+++ b/relay/restore.go
@@ -23,11 +23,11 @@ func (pr *Prover) restoreELC(ctx context.Context, counterparty core.FinalityAwar
 		return fmt.Errorf("client '%v' already exists", elcClientID)
 	}
 
-	cplatestHeight, err := counterparty.LatestHeight(context.TODO())
+	cplatestHeight, err := counterparty.LatestHeight(ctx)
 	if err != nil {
 		return err
 	}
-	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(context.TODO(), cplatestHeight))
+	counterpartyClientRes, err := counterparty.QueryClientState(core.NewQueryContext(ctx, cplatestHeight))
 	if err != nil {
 		return fmt.Errorf("failed to query client state: height=%v %w", cplatestHeight, err)
 	}
@@ -45,7 +45,7 @@ func (pr *Prover) restoreELC(ctx context.Context, counterparty core.FinalityAwar
 
 	pr.getLogger().Info("try to restore ELC state", "height", restoreHeight)
 
-	counterpartyConsRes, err := counterparty.QueryClientConsensusState(core.NewQueryContext(context.TODO(), cplatestHeight), restoreHeight)
+	counterpartyConsRes, err := counterparty.QueryClientConsensusState(core.NewQueryContext(ctx, cplatestHeight), restoreHeight)
 	if err != nil {
 		return err
 	}
@@ -75,7 +75,7 @@ func (pr *Prover) restoreELC(ctx context.Context, counterparty core.FinalityAwar
 		return fmt.Errorf("allowed advisory ids mismatch: expected %v, but got %v", pr.config.AllowedAdvisoryIds, clientState.AllowedAdvisoryIds)
 	}
 
-	originClientState, originConsensusState, err := pr.originProver.CreateInitialLightClientState(context.TODO(), clientState.LatestHeight)
+	originClientState, originConsensusState, err := pr.originProver.CreateInitialLightClientState(ctx, clientState.LatestHeight)
 	if err != nil {
 		return fmt.Errorf("failed to create initial light client state: height=%v %w", clientState.LatestHeight, err)
 	}
@@ -87,11 +87,11 @@ func (pr *Prover) restoreELC(ctx context.Context, counterparty core.FinalityAwar
 	if err != nil {
 		return err
 	}
-	tmpEKI, err := pr.selectNewEnclaveKey(context.TODO())
+	tmpEKI, err := pr.selectNewEnclaveKey(ctx)
 	if err != nil {
 		return err
 	}
-	res, err := pr.lcpServiceClient.CreateClient(context.TODO(), &elc.MsgCreateClient{
+	res, err := pr.lcpServiceClient.CreateClient(ctx, &elc.MsgCreateClient{
 		ClientId:       elcClientID,
 		ClientState:    originAnyClientState,
 		ConsensusState: originAnyConsensusState,

--- a/relay/tendermint/cmd/light.go
+++ b/relay/tendermint/cmd/light.go
@@ -43,7 +43,7 @@ func initLightCmd(ctx *config.Context) *cobra.Command {
 			}
 			chain := c.Chain.(*tendermint.Chain)
 			prover := c.Prover.(*relay.Prover).GetOriginProver().(*tendermint.Prover)
-			db, df, err := prover.NewLightDB()
+			db, df, err := prover.NewLightDB(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -64,13 +64,13 @@ func initLightCmd(ctx *config.Context) *cobra.Command {
 
 			switch {
 			case force: // force initialization from trusted node
-				_, err := prover.LightClientWithoutTrust(db)
+				_, err := prover.LightClientWithoutTrust(cmd.Context(), db)
 				if err != nil {
 					return err
 				}
 				fmt.Printf("successfully created light client for %s by trusting endpoint %s...\n", chain.ChainID(), chain.Config().RpcAddr)
 			case height > 0 && len(hash) > 0: // height and hash are given
-				_, err = prover.LightClientWithTrust(db, prover.TrustOptions(height, hash))
+				_, err = prover.LightClientWithTrust(cmd.Context(), db, prover.TrustOptions(height, hash))
 				if err != nil {
 					return wrapInitFailed(err)
 				}
@@ -97,12 +97,12 @@ func updateLightCmd(ctx *config.Context) *cobra.Command {
 				return err
 			}
 			prover := c.Prover.(*relay.Prover).GetOriginProver().(*tendermint.Prover)
-			bh, err := prover.GetLatestLightHeader()
+			bh, err := prover.GetLatestLightHeader(cmd.Context())
 			if err != nil {
 				return err
 			}
 
-			ah, err := prover.UpdateLightClient(0)
+			ah, err := prover.UpdateLightClient(cmd.Context(), 0)
 			if err != nil {
 				return err
 			}
@@ -134,7 +134,7 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 			var header *tmclient.Header
 			switch len(args) {
 			case 1:
-				header, err = prover.GetLatestLightHeader()
+				header, err = prover.GetLatestLightHeader(cmd.Context())
 				if err != nil {
 					return err
 				}
@@ -146,7 +146,7 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 				}
 
 				if height == 0 {
-					height, err = prover.GetLatestLightHeight()
+					height, err = prover.GetLatestLightHeight(cmd.Context())
 					if err != nil {
 						return err
 					}
@@ -156,7 +156,7 @@ func lightHeaderCmd(ctx *config.Context) *cobra.Command {
 					}
 				}
 
-				header, err = prover.GetLightSignedHeaderAtHeight(height)
+				header, err = prover.GetLightSignedHeaderAtHeight(cmd.Context(), height)
 				if err != nil {
 					return err
 				}
@@ -179,7 +179,7 @@ func deleteLightCmd(ctx *config.Context) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete [chain-id]",
 		Aliases: []string{"d"},
-		Short:   "wipe the light client database, forcing re-initialzation on the next run",
+		Short:   "wipe the light client database, forcing re-initialization on the next run",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			c, err := ctx.Config.GetChain(args[0])

--- a/sgx/flags.go
+++ b/sgx/flags.go
@@ -5,14 +5,14 @@ import (
 	"github.com/oasisprotocol/oasis-core/go/common/sgx/ias"
 )
 
-// SetAllowDebugEnclave will enable running and communicating with enclaves
+// SetAllowDebugEnclaves will enable running and communicating with enclaves
 // with debug flag enabled in AVR for the remainder of the process' lifetime.
 func SetAllowDebugEnclaves() {
 	ias.SetAllowDebugEnclaves()
 	dcap.SetAllowDebugEnclaves()
 }
 
-// UnsetAllowDebugEnclave will disable running and communicating with enclaves
+// UnsetAllowDebugEnclaves will disable running and communicating with enclaves
 // with debug flag enabled in AVR for the remainder of the process' lifetime.
 func UnsetAllowDebugEnclaves() {
 	ias.UnsetAllowDebugEnclaves()


### PR DESCRIPTION
This PR is the subsequent PR of https://github.com/datachainlab/lcp-go/pull/40 and replaces `context.TODO()` with an appropriate context.
To avoid conflicts, this PR is based on the branch of https://github.com/datachainlab/lcp-go/pull/39, so I will not merge this PR until it  is merged.