### PR TITLE
Fix to use `output.validity.not_after + 1` as key's `expiredAt` if the client state's key expiration is zero

### DIFF
--- a/light-clients/lcp/types/update.go
+++ b/light-clients/lcp/types/update.go
@@ -691,9 +691,9 @@ func (cs ClientState) GetOperators() []common.Address {
 
 func (cs ClientState) GetDCAPKeyExpiredAt(validity dcap.ValidityIntersection) time.Time {
 	if cs.KeyExpiration == 0 {
-		return time.Unix(int64(validity.NotAfterMin), 0)
+		return time.Unix(int64(validity.NotAfterMin+1), 0)
 	}
-	return time.Unix(int64(min(validity.NotAfterMin, validity.NotBeforeMax+cs.KeyExpiration)), 0)
+	return time.Unix(int64(min(validity.NotAfterMin+1, validity.NotBeforeMax+cs.KeyExpiration)), 0)
 }
 
 func (cs ClientState) getKeyExpiration() time.Duration {

--- a/relay/enclave/query.go
+++ b/relay/enclave/query.go
@@ -30,13 +30,13 @@ func (eki *EnclaveKeyInfo) GetExpiredAt(keyExpiration time.Duration) time.Time {
 }
 
 func calculateDCAPKeyExpiration(validity Validity, keyExpiration time.Duration) time.Time {
-	notAfter := time.Unix(int64(validity.NotAfter), 0)
+	maxKeyExpiredAt := time.Unix(int64(validity.NotAfter+1), 0)
 	if keyExpiration == 0 {
-		return notAfter
+		return maxKeyExpiredAt
 	}
 	tm := time.Unix(int64(validity.NotBefore), 0).Add(keyExpiration)
-	if tm.After(notAfter) {
-		return notAfter
+	if tm.After(maxKeyExpiredAt) {
+		return maxKeyExpiredAt
 	}
 	return tm
 }

--- a/scripts/run_e2e_test.sh
+++ b/scripts/run_e2e_test.sh
@@ -7,6 +7,7 @@ E2E_TEST_DIR=./tests/e2e/cases/tm2tm
 OPERATORS_ENABLED=false
 NO_RUN_LCP=false
 export LCP_ENCLAVE_DEBUG=0
+# should be 0 or greater than `key_update_buffer_time` in the config
 export LCP_KEY_EXPIRATION=86400
 # LCP_RISC0_IMAGE_ID must be set to the same value as in the LCP service
 LCP_RISC0_IMAGE_ID=${LCP_RISC0_IMAGE_ID:-0x7238627eef5fe9a95d8cadd1a74c3bb1f703cf312699ce93f4c8aa448f122e6f}


### PR DESCRIPTION
ref. https://github.com/datachainlab/lcp-solidity/pull/34