### PR TITLE
Update lcp revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ lcp-go includes the followings:
 
 ## Dependencies
 
-- [lcp v0.2.14](https://github.com/datachainlab/lcp/releases/tag/v0.2.14)
+- [lcp v0.2.15](https://github.com/datachainlab/lcp/releases/tag/v0.2.15)
 - [ibc-go v8.2](https://github.com/cosmos/ibc-go/releases/tag/v8.2.0)
 - [yui-relayer v0.5.13](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.5.13)
 


### PR DESCRIPTION
The latest revision of lcp includes the changes in https://github.com/datachainlab/lcp/pull/134, which is necessary to prepare the test environment.