### PR TITLE
debug: observe UpdateClientStream receive failure

### DIFF
--- a/relay/config.go
+++ b/relay/config.go
@@ -21,6 +21,10 @@ const (
 	DefaultMessageAggregationBatchSize = 8
 	// It is necessary to subtract from 4 MB to account for metadata size.
 	DefaultMaxChunkSize = 4*1024*1024 - 1024
+	// DefaultGRPCMaxMsgSize is the maximum gRPC message size for LCP service communication.
+	// The default gRPC limit (4 MB) is insufficient when AggregateMessages batches
+	// accumulate multiple UpdateClient results.
+	DefaultGRPCMaxMsgSize = 32 * 1024 * 1024 // 32 MB
 )
 
 var _ core.ProverConfig = (*ProverConfig)(nil)

--- a/relay/elcupdater/grpc/client.go
+++ b/relay/elcupdater/grpc/client.go
@@ -17,6 +17,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
+const (
+	// defaultGRPCMaxMsgSize is the maximum gRPC message size for ELCUpdater communication.
+	// Must match defaultGRPCMaxMsgSize. Defined separately to avoid import cycle.
+	defaultGRPCMaxMsgSize = 32 * 1024 * 1024 // 32 MB
+)
+
 // GetSequentialRecords retrieves sequential ELCUpdateRecords from gRPC server
 // If toHeight is not nil, stops when reaching a record with that ToHeight
 func GetSequentialRecords(ctx context.Context, grpcAddress string, chainID string, counterpartyChainID string, fromHeight exported.Height, toHeight exported.Height) ([]*storage.Record, error) {
@@ -43,6 +49,10 @@ func GetSequentialRecords(ctx context.Context, grpcAddress string, chainID strin
 	conn, err := grpc.NewClient(grpcAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(defaultGRPCMaxMsgSize),
+			grpc.MaxCallSendMsgSize(defaultGRPCMaxMsgSize),
+		),
 	)
 	if err != nil {
 		logger.ErrorContext(ctx, "GetSequentialRecords request failed - connection error", err)
@@ -102,6 +112,10 @@ func GetLatestRecord(ctx context.Context, grpcAddress string, chainID string, co
 	conn, err := grpc.NewClient(grpcAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(defaultGRPCMaxMsgSize),
+			grpc.MaxCallSendMsgSize(defaultGRPCMaxMsgSize),
+		),
 	)
 	if err != nil {
 		logger.ErrorContext(ctx, "GetLatestELCUpdate request failed - connection error", err)

--- a/relay/elcupdater/module/service.go
+++ b/relay/elcupdater/module/service.go
@@ -195,6 +195,8 @@ func (srv *Service) runGRPCServer(ctx context.Context) error {
 	}
 
 	grpcServer := grpc.NewServer(
+		grpc.MaxRecvMsgSize(lcp.DefaultGRPCMaxMsgSize),
+		grpc.MaxSendMsgSize(lcp.DefaultGRPCMaxMsgSize),
 		grpc.UnaryInterceptor(recovery.UnaryServerInterceptor(recovery.WithRecoveryHandler(recoveryHandler))),
 	)
 

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -61,6 +61,10 @@ func NewProver(config ProverConfig, originChain core.Chain, originProver core.Pr
 		grpc.WithBlock(),
 		grpc.WithTimeout(config.GetDialTimeout()),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(DefaultGRPCMaxMsgSize),
+			grpc.MaxCallSendMsgSize(DefaultGRPCMaxMsgSize),
+		),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to LCP service: %w", err)

--- a/relay/update_client.go
+++ b/relay/update_client.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/gogoproto/proto"
 	"github.com/datachainlab/lcp-go/relay/elc"
+	"github.com/hyperledger-labs/yui-relayer/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -91,6 +93,7 @@ func updateClient(ctx context.Context, chunkSize uint32, client LCPServiceClient
 			err,
 		)
 	}
+	logUpdateClientResponse(ctx, anyHeader, chunkSize, chunks, resp)
 	return resp, nil
 }
 
@@ -114,4 +117,28 @@ func lastChunkSize(chunks [][]byte) int {
 		return 0
 	}
 	return len(chunks[len(chunks)-1])
+}
+
+func logUpdateClientResponse(ctx context.Context, anyHeader *types.Any, chunkSize uint32, chunks [][]byte, resp *elc.MsgUpdateClientResponse) {
+	logger := log.GetLogger()
+	if logger == nil {
+		return
+	}
+
+	const defaultGRPCMaxRecvMsgSize = 4 * 1024 * 1024
+	responseProtoSize := proto.Size(resp)
+	logger.WithModule("lcp-prover").InfoContext(
+		ctx,
+		"UpdateClientStream response received",
+		"header_bytes", len(anyHeader.Value),
+		"chunk_size", chunkSize,
+		"chunk_count", len(chunks),
+		"last_chunk_size", lastChunkSize(chunks),
+		"response_proto_size", responseProtoSize,
+		"response_message_bytes", len(resp.Message),
+		"response_signature_bytes", len(resp.Signature),
+		"response_exceeds_default_4mb", responseProtoSize > defaultGRPCMaxRecvMsgSize,
+		"max_recv_msg_size", DefaultGRPCMaxMsgSize,
+		"max_send_msg_size", DefaultGRPCMaxMsgSize,
+	)
 }

--- a/relay/update_client.go
+++ b/relay/update_client.go
@@ -5,12 +5,24 @@ import (
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/datachainlab/lcp-go/relay/elc"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func updateClient(ctx context.Context, chunkSize uint32, client LCPServiceClient, anyHeader *types.Any, elcClientID string, includeState bool, signer []byte) (*elc.MsgUpdateClientResponse, error) {
-	stream, err := client.UpdateClientStream(ctx)
+	stream, err := client.UpdateClientStream(
+		ctx,
+		grpc.MaxCallRecvMsgSize(DefaultGRPCMaxMsgSize),
+		grpc.MaxCallSendMsgSize(DefaultGRPCMaxMsgSize),
+	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call UpdateClientStream: %w", err)
+		return nil, fmt.Errorf(
+			"failed to call UpdateClientStream: max_recv_msg_size=%d max_send_msg_size=%d %w",
+			DefaultGRPCMaxMsgSize,
+			DefaultGRPCMaxMsgSize,
+			err,
+		)
 	}
 	if err = stream.Send(&elc.MsgUpdateClientStreamChunk{
 		Chunk: &elc.MsgUpdateClientStreamChunk_Init{
@@ -40,7 +52,46 @@ func updateClient(ctx context.Context, chunkSize uint32, client LCPServiceClient
 			return nil, fmt.Errorf("failed to send header chunk: index=%d, %w", i, err)
 		}
 	}
-	return stream.CloseAndRecv()
+	if err := stream.CloseSend(); err != nil {
+		return nil, fmt.Errorf(
+			"failed to close UpdateClientStream send: header_bytes=%d chunk_size=%d chunk_count=%d max_recv_msg_size=%d max_send_msg_size=%d %w",
+			len(anyHeader.Value),
+			chunkSize,
+			len(chunks),
+			DefaultGRPCMaxMsgSize,
+			DefaultGRPCMaxMsgSize,
+			err,
+		)
+	}
+
+	resp := new(elc.MsgUpdateClientResponse)
+	if err := stream.RecvMsg(resp); err != nil {
+		st, ok := status.FromError(err)
+		if ok && st.Code() == codes.ResourceExhausted {
+			return nil, fmt.Errorf(
+				"failed to receive UpdateClientStream response: code=%s header_bytes=%d chunk_size=%d chunk_count=%d last_chunk_size=%d max_recv_msg_size=%d max_send_msg_size=%d raw=%w",
+				st.Code(),
+				len(anyHeader.Value),
+				chunkSize,
+				len(chunks),
+				lastChunkSize(chunks),
+				DefaultGRPCMaxMsgSize,
+				DefaultGRPCMaxMsgSize,
+				err,
+			)
+		}
+		return nil, fmt.Errorf(
+			"failed to receive UpdateClientStream response: header_bytes=%d chunk_size=%d chunk_count=%d last_chunk_size=%d max_recv_msg_size=%d max_send_msg_size=%d %w",
+			len(anyHeader.Value),
+			chunkSize,
+			len(chunks),
+			lastChunkSize(chunks),
+			DefaultGRPCMaxMsgSize,
+			DefaultGRPCMaxMsgSize,
+			err,
+		)
+	}
+	return resp, nil
 }
 
 func splitBytes(data []byte, size uint32) ([][]byte, error) {
@@ -56,4 +107,11 @@ func splitBytes(data []byte, size uint32) ([][]byte, error) {
 		chunks = append(chunks, data[i:end])
 	}
 	return chunks, nil
+}
+
+func lastChunkSize(chunks [][]byte) int {
+	if len(chunks) == 0 {
+		return 0
+	}
+	return len(chunks[len(chunks)-1])
 }


### PR DESCRIPTION
## Summary\n- add explicit per-call gRPC message size options to UpdateClientStream\n- split CloseAndRecv into CloseSend + RecvMsg for direct receive-failure observation\n- include chunk/header/message-size context in the receive error path\n\n## Testing\n- go test ./relay/...