### PR TITLE
Log existing ELC reuse details

### DIFF
--- a/relay/lcp.go
+++ b/relay/lcp.go
@@ -856,6 +856,11 @@ func (pr *Prover) createELC(ctx context.Context, elcClientID string, height ibce
 	if err != nil {
 		return nil, err
 	} else if res.Found {
+		pr.getLogger().InfoContext(ctx, "reusing existing ELC client",
+			"elc_client_id", elcClientID,
+			"requested_height_is_nil", height == nil,
+			"requested_height", formatHeightForLog(height),
+		)
 		return nil, nil
 	}
 	// NOTE: Query the LCP for available keys, but no need to register it into on-chain here
@@ -881,6 +886,13 @@ func (pr *Prover) createELC(ctx context.Context, elcClientID string, height ibce
 		ConsensusState: anyOriginConsensusState,
 		Signer:         tmpEKI.GetEnclaveKeyAddress().Bytes(),
 	})
+}
+
+func formatHeightForLog(height ibcexported.Height) string {
+	if height == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d-%d", height.GetRevisionNumber(), height.GetRevisionHeight())
 }
 
 func ActivateClient(ctx context.Context, pathEnd *core.PathEnd, src, dst *core.ProvableChain, retryInterval time.Duration, retryMaxAttempts uint) error {

--- a/relay/prover.go
+++ b/relay/prover.go
@@ -184,7 +184,11 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 	if res, err := pr.createELC(ctx, pr.config.ElcClientId, height); err != nil {
 		return nil, nil, fmt.Errorf("failed to create ELC: %w", err)
 	} else if res == nil {
-		pr.getLogger().InfoContext(ctx, "no need to create ELC", "elc_client_id", pr.config.ElcClientId)
+		pr.getLogger().InfoContext(ctx, "no need to create ELC",
+			"elc_client_id", pr.config.ElcClientId,
+			"requested_height_is_nil", height == nil,
+			"requested_height", formatHeightForLog(height),
+		)
 	}
 
 	// NOTE after creates client, register an enclave key into the client state


### PR DESCRIPTION
## Summary
- log when an existing ELC client is reused instead of being created
- include whether the requested height was nil and the requested height value
- surface the same fields from the top-level create-client path for easier relayer log inspection

## Testing
- go test ./relay/...