### PR TITLE
Fix default value for --cleanup-age

### DIFF
--- a/relay/elcupdater/module/cmd.go
+++ b/relay/elcupdater/module/cmd.go
@@ -336,7 +336,7 @@ func serverCmd(ctx *config.Context) *cobra.Command {
 			if cleanupAgeStr != "" && cleanupAgeStr != "0" {
 				cleanupAge, err = time.ParseDuration(cleanupAgeStr)
 				if err != nil {
-					return fmt.Errorf("invalid cleanup duration format '%s': %w (examples: '7d', '24h', '30m')", cleanupAgeStr, err)
+					return fmt.Errorf("invalid cleanup duration format '%s': %w (examples: '168h', '24h', '30m')", cleanupAgeStr, err)
 				}
 			}
 
@@ -527,7 +527,7 @@ func bindPFlagUpdateInterval(cmd *cobra.Command) *cobra.Command {
 }
 
 func bindPFlagCleanupAge(cmd *cobra.Command) *cobra.Command {
-	cmd.Flags().String(flagCleanupAge, "7d", "cleanup records older than this age (examples: '7d', '24h', '30m', '600s', empty or '0' to disable)")
+	cmd.Flags().String(flagCleanupAge, "168h", "cleanup records older than this age (examples: '168h', '24h', '30m', '600s', empty or '0' to disable)")
 	if err := viper.BindPFlag(flagCleanupAge, cmd.Flags().Lookup(flagCleanupAge)); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This value is parsed by time.ParseDuration which [doesn't support](https://pkg.go.dev/time#ParseDuration) "d" as a unit.

> A duration string is a possibly signed sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".

Currently, if you attempt to run the ELC updater without specifying `--cleanup-age`, the following error occurs:

```
Error: invalid cleanup duration format '7d': time: unknown unit "d" in duration "7d" (examples: '7d', '24h', '30m')
```