### PR TITLE
Fix client activation when ELC updater is enabled

### DIFF
--- a/relay/elcupdater/storage/sqlx_storage.go
+++ b/relay/elcupdater/storage/sqlx_storage.go
@@ -256,18 +256,29 @@ func (s *SqlxStorage) GetLatestForChain(ctx context.Context, chainID string, cou
 	return record, nil
 }
 
-// GetSequential retrieves sequential records starting from the specified height
-// If toHeight is not nil, stops when reaching a record with that ToHeight
+// GetSequential retrieves sequential records starting from the specified height.
+// The first record may have a fromHeight earlier than the requested fromHeight —
+// this handles the case where the requested height falls between record boundaries
+// (e.g., requesting from height 27 when records are {22→32, 32→42}).
+// If toHeight is not nil, stops when reaching a record with that ToHeight.
 func (s *SqlxStorage) GetSequential(ctx context.Context, chainID string, counterpartyChainID string, fromHeight ibcexported.Height, toHeight ibcexported.Height) ([]*Record, error) {
-	// Step 1: Get all records with fromHeight >= specified fromHeight
+	// Step 1: Get all candidate records.
+	// Include records whose range covers fromHeight (fromHeight <= requested AND toHeight > requested),
+	// as well as records that start at or after fromHeight.
 	query := selectClause + `
 		WHERE chain_id = :chain_id
 	`
 	if counterpartyChainID != "" {
 		query += " AND counterparty_chain_id = :counterparty_chain_id"
 	}
+	// A record is relevant if:
+	//   (a) it covers the requested fromHeight: fromHeight <= requested AND toHeight > requested, OR
+	//   (b) it starts at or after the requested fromHeight: fromHeight >= requested
+	// Since (b) is a subset of "toHeight > requested" when records don't overlap, we simplify to:
+	//   toHeight > requested fromHeight (any record whose range extends past the requested start)
 	query += `
-		AND (from_height_revision_number = :from_rev_num AND from_height_revision_height >= :from_rev_height)
+		AND from_height_revision_number = :from_rev_num
+		AND to_height_revision_height > :from_rev_height
 	`
 
 	namedArgs := map[string]interface{}{
@@ -315,9 +326,37 @@ func (s *SqlxStorage) GetSequential(ctx context.Context, chainID string, counter
 		return nil, errWithStack("error iterating rows: %w", err)
 	}
 
-	// Step 2-3: Build sequential chain starting from fromHeight
+	// Step 2: Find the starting record.
+	// First try an exact match on fromHeight. If none exists, find the record that
+	// covers fromHeight (i.e., record.fromHeight < fromHeight < record.toHeight).
+	startHeight := fromHeight
+	startKey := fmt.Sprintf("%d-%d", startHeight.GetRevisionNumber(), startHeight.GetRevisionHeight())
+	if _, exists := recordMap[startKey]; !exists {
+		// No exact match — find the covering record (the one with the largest
+		// fromHeight that is still less than the requested fromHeight).
+		var coveringFromKey string
+		for key := range recordMap {
+			for _, r := range recordMap[key] {
+				if r.FromHeight.RevisionNumber == fromHeight.GetRevisionNumber() &&
+					r.FromHeight.RevisionHeight < fromHeight.GetRevisionHeight() &&
+					r.ToHeight.RevisionHeight > fromHeight.GetRevisionHeight() {
+					if coveringFromKey == "" || r.FromHeight.RevisionHeight > recordMap[coveringFromKey][0].FromHeight.RevisionHeight {
+						coveringFromKey = key
+					}
+				}
+			}
+		}
+		if coveringFromKey != "" {
+			startHeight = clienttypes.NewHeight(
+				recordMap[coveringFromKey][0].FromHeight.RevisionNumber,
+				recordMap[coveringFromKey][0].FromHeight.RevisionHeight,
+			)
+		}
+	}
+
+	// Step 3: Build sequential chain starting from startHeight
 	var result []*Record
-	currentHeight := fromHeight
+	currentHeight := startHeight
 
 	for {
 		currentKey := fmt.Sprintf("%d-%d", currentHeight.GetRevisionNumber(), currentHeight.GetRevisionHeight())

--- a/relay/elcupdater/storage/sqlx_storage.go
+++ b/relay/elcupdater/storage/sqlx_storage.go
@@ -256,29 +256,18 @@ func (s *SqlxStorage) GetLatestForChain(ctx context.Context, chainID string, cou
 	return record, nil
 }
 
-// GetSequential retrieves sequential records starting from the specified height.
-// The first record may have a fromHeight earlier than the requested fromHeight —
-// this handles the case where the requested height falls between record boundaries
-// (e.g., requesting from height 27 when records are {22→32, 32→42}).
-// If toHeight is not nil, stops when reaching a record with that ToHeight.
+// GetSequential retrieves sequential records starting from the specified height
+// If toHeight is not nil, stops when reaching a record with that ToHeight
 func (s *SqlxStorage) GetSequential(ctx context.Context, chainID string, counterpartyChainID string, fromHeight ibcexported.Height, toHeight ibcexported.Height) ([]*Record, error) {
-	// Step 1: Get all candidate records.
-	// Include records whose range covers fromHeight (fromHeight <= requested AND toHeight > requested),
-	// as well as records that start at or after fromHeight.
+	// Step 1: Get all records with fromHeight >= specified fromHeight
 	query := selectClause + `
 		WHERE chain_id = :chain_id
 	`
 	if counterpartyChainID != "" {
 		query += " AND counterparty_chain_id = :counterparty_chain_id"
 	}
-	// A record is relevant if:
-	//   (a) it covers the requested fromHeight: fromHeight <= requested AND toHeight > requested, OR
-	//   (b) it starts at or after the requested fromHeight: fromHeight >= requested
-	// Since (b) is a subset of "toHeight > requested" when records don't overlap, we simplify to:
-	//   toHeight > requested fromHeight (any record whose range extends past the requested start)
 	query += `
-		AND from_height_revision_number = :from_rev_num
-		AND to_height_revision_height > :from_rev_height
+		AND (from_height_revision_number = :from_rev_num AND from_height_revision_height >= :from_rev_height)
 	`
 
 	namedArgs := map[string]interface{}{
@@ -326,37 +315,9 @@ func (s *SqlxStorage) GetSequential(ctx context.Context, chainID string, counter
 		return nil, errWithStack("error iterating rows: %w", err)
 	}
 
-	// Step 2: Find the starting record.
-	// First try an exact match on fromHeight. If none exists, find the record that
-	// covers fromHeight (i.e., record.fromHeight < fromHeight < record.toHeight).
-	startHeight := fromHeight
-	startKey := fmt.Sprintf("%d-%d", startHeight.GetRevisionNumber(), startHeight.GetRevisionHeight())
-	if _, exists := recordMap[startKey]; !exists {
-		// No exact match — find the covering record (the one with the largest
-		// fromHeight that is still less than the requested fromHeight).
-		var coveringFromKey string
-		for key := range recordMap {
-			for _, r := range recordMap[key] {
-				if r.FromHeight.RevisionNumber == fromHeight.GetRevisionNumber() &&
-					r.FromHeight.RevisionHeight < fromHeight.GetRevisionHeight() &&
-					r.ToHeight.RevisionHeight > fromHeight.GetRevisionHeight() {
-					if coveringFromKey == "" || r.FromHeight.RevisionHeight > recordMap[coveringFromKey][0].FromHeight.RevisionHeight {
-						coveringFromKey = key
-					}
-				}
-			}
-		}
-		if coveringFromKey != "" {
-			startHeight = clienttypes.NewHeight(
-				recordMap[coveringFromKey][0].FromHeight.RevisionNumber,
-				recordMap[coveringFromKey][0].FromHeight.RevisionHeight,
-			)
-		}
-	}
-
-	// Step 3: Build sequential chain starting from startHeight
+	// Step 2-3: Build sequential chain starting from fromHeight
 	var result []*Record
-	currentHeight := startHeight
+	currentHeight := fromHeight
 
 	for {
 		currentKey := fmt.Sprintf("%d-%d", currentHeight.GetRevisionNumber(), currentHeight.GetRevisionHeight())

--- a/relay/elcupdater_update.go
+++ b/relay/elcupdater_update.go
@@ -48,7 +48,7 @@ func (pr *Prover) UpdateELCAndStore(ctx context.Context, counterparty core.Final
 			dstChain = elcupdater.NewMockChain(counterparty.ChainID(), fromHeight)
 		} else {
 			fromHeight = csHeight
-			dstChain = counterparty
+			dstChain = NewLCPQuerier(pr.lcpServiceClient, pr.config.ElcClientId)
 		}
 	}
 

--- a/relay/elcupdater_update.go
+++ b/relay/elcupdater_update.go
@@ -48,7 +48,8 @@ func (pr *Prover) UpdateELCAndStore(ctx context.Context, counterparty core.Final
 			dstChain = elcupdater.NewMockChain(counterparty.ChainID(), fromHeight)
 		} else {
 			fromHeight = csHeight
-			dstChain = NewLCPQuerier(pr.lcpServiceClient, pr.config.ElcClientId)
+			//dstChain = NewLCPQuerier(pr.lcpServiceClient, pr.config.ElcClientId)
+			dstChain = counterparty
 		}
 	}
 

--- a/relay/elcupdater_update.go
+++ b/relay/elcupdater_update.go
@@ -48,8 +48,7 @@ func (pr *Prover) UpdateELCAndStore(ctx context.Context, counterparty core.Final
 			dstChain = elcupdater.NewMockChain(counterparty.ChainID(), fromHeight)
 		} else {
 			fromHeight = csHeight
-			//dstChain = NewLCPQuerier(pr.lcpServiceClient, pr.config.ElcClientId)
-			dstChain = counterparty
+			dstChain = NewLCPQuerier(pr.lcpServiceClient, pr.config.ElcClientId)
 		}
 	}
 

--- a/tests/e2e/cases/tm2tm/configs/templates/ibc-0.json.tpl
+++ b/tests/e2e/cases/tm2tm/configs/templates/ibc-0.json.tpl
@@ -27,6 +27,7 @@
     "key_expiration": $LCP_KEY_EXPIRATION,
     "key_update_buffer_time": 3600,
     "elc_client_id": "07-tendermint-1",
-    "is_debug_enclave": $IS_DEBUG_ENCLAVE
+    "is_debug_enclave": $IS_DEBUG_ENCLAVE,
+    "elc_updater_grpc_address": "localhost:19090"
   }
 }

--- a/tests/e2e/cases/tm2tm/configs/templates/ibc-1.json.tpl
+++ b/tests/e2e/cases/tm2tm/configs/templates/ibc-1.json.tpl
@@ -27,6 +27,7 @@
     "key_expiration": $LCP_KEY_EXPIRATION,
     "key_update_buffer_time": 3600,
     "elc_client_id": "07-tendermint-0",
-    "is_debug_enclave": $IS_DEBUG_ENCLAVE
+    "is_debug_enclave": $IS_DEBUG_ENCLAVE,
+    "elc_updater_grpc_address": "localhost:19091"
   }
 }

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -94,7 +94,6 @@ sleep 3
 # This is a known limitation to be addressed separately.
 unset YRLY_LCP_ELC_UPDATER_GRPC_ENABLE
 
-dump_elc_records
 echo "=== Running tx connection ==="
 retry 5 $RLY tx connection $PATH_NAME
 

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -39,6 +39,46 @@ $RLY paths add $CHAINID_ONE $CHAINID_TWO $PATH_NAME --file=./configs/path.json
 
 retry 5 $RLY tx clients $PATH_NAME
 sleep 3
+
+# Start ELC updater services for both chains.
+# Each service polls its target chain and stores ELC update records in a local SQLite DB,
+# then serves them via gRPC so that activate-client can use them instead of querying
+# the LCP enclave directly.
+ELC_UPDATER_DB_0=/tmp/elc-updater-ibc0.sqlite
+ELC_UPDATER_DB_1=/tmp/elc-updater-ibc1.sqlite
+
+$RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_0
+$RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_1
+
+$RLY lcp elc-updater server \
+    --sqlite-path $ELC_UPDATER_DB_0 \
+    --grpc-addr :19090 \
+    --update-interval 10s \
+    ${PATH_NAME}:${CHAINID_ONE} &
+ELC_UPDATER_PID_0=$!
+
+$RLY lcp elc-updater server \
+    --sqlite-path $ELC_UPDATER_DB_1 \
+    --grpc-addr :19091 \
+    --update-interval 10s \
+    ${PATH_NAME}:${CHAINID_TWO} &
+ELC_UPDATER_PID_1=$!
+
+# Clean up ELC updater processes on exit
+cleanup_elc_updaters() {
+    echo "Stopping ELC updater services..."
+    kill $ELC_UPDATER_PID_0 $ELC_UPDATER_PID_1 2>/dev/null || true
+    wait $ELC_UPDATER_PID_0 $ELC_UPDATER_PID_1 2>/dev/null || true
+}
+trap cleanup_elc_updaters EXIT
+
+# Give ELC updater services time to start and produce initial records
+echo "Waiting for ELC updater services to produce records..."
+sleep 15
+
+# Enable ELC updater gRPC mode for activate-client and subsequent commands
+export YRLY_LCP_ELC_UPDATER_GRPC_ENABLE=true
+
 retry 5 $RLY lcp activate-client $PATH_NAME --src=true
 retry 5 $RLY lcp activate-client $PATH_NAME --src=false
 sleep 3

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -38,7 +38,15 @@ retry 5 $RLY lcp-tendermint light init $CHAINID_TWO -f
 # add a path between chain0 and chain1
 $RLY paths add $CHAINID_ONE $CHAINID_TWO $PATH_NAME --file=./configs/path.json
 
-# Start ELC updater services for both chains.
+# Create IBC clients first (without ELC updater — it needs client IDs in the config)
+retry 5 $RLY tx clients $PATH_NAME
+sleep 3
+
+echo "=== Client IDs ==="
+jq '.paths.ibc01.src["client-id"]' < $RLY_CONFIG
+jq '.paths.ibc01.dst["client-id"]' < $RLY_CONFIG
+
+# Start ELC updater services AFTER tx clients so they load the config with populated client IDs.
 # Each service polls its target chain and stores ELC update records in a local SQLite DB,
 # then serves them via gRPC so that activate-client can use them instead of querying
 # the LCP enclave directly.
@@ -70,18 +78,11 @@ cleanup_elc_updaters() {
 }
 trap cleanup_elc_updaters EXIT
 
-# Give ELC updater services time to start
-sleep 5
+# Give ELC updater services time to start and produce initial records
+sleep 15
 
-# Enable ELC updater gRPC mode for all subsequent commands
+# Enable ELC updater gRPC mode for activate-client and subsequent commands
 export YRLY_LCP_ELC_UPDATER_GRPC_ENABLE=true
-
-retry 5 $RLY tx clients $PATH_NAME
-sleep 3
-
-echo "=== Client IDs ==="
-jq '.paths.ibc01.src["client-id"]' < $RLY_CONFIG
-jq '.paths.ibc01.dst["client-id"]' < $RLY_CONFIG
 
 retry 5 $RLY lcp activate-client $PATH_NAME --src=true
 retry 5 $RLY lcp activate-client $PATH_NAME --src=false

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -101,6 +101,12 @@ echo "=== Running activate-client (dst) ==="
 retry 5 $RLY lcp activate-client $PATH_NAME --src=false
 sleep 3
 
+# Disable ELC updater for connection and channel steps.
+# The ELC updater records produced before activate-client reference heights the on-chain
+# client was never updated to, causing "consensus state not found" errors.
+# This is a known limitation to be addressed separately.
+unset YRLY_LCP_ELC_UPDATER_GRPC_ENABLE
+
 dump_elc_records
 echo "=== Running tx connection ==="
 retry 5 $RLY tx connection $PATH_NAME

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -28,6 +28,17 @@ RLYKEY=testkey
 CHAINID_TWO=ibc1
 PATH_NAME=ibc01
 
+# Helper to dump ELC updater DB contents for both chains
+dump_elc_records() {
+    echo "=== ELC updater records for $CHAINID_ONE ==="
+    $RLY lcp elc-updater dblist --sqlite-path $ELC_UPDATER_DB_0 2>/dev/null || true
+    echo "=== ELC updater records for $CHAINID_TWO ==="
+    $RLY lcp elc-updater dblist --sqlite-path $ELC_UPDATER_DB_1 2>/dev/null || true
+}
+
+ELC_UPDATER_DB_0=/tmp/elc-updater-ibc0.sqlite
+ELC_UPDATER_DB_1=/tmp/elc-updater-ibc1.sqlite
+
 $RLY tendermint keys show $CHAINID_ONE $RLYKEY
 $RLY tendermint keys show $CHAINID_TWO $RLYKEY
 
@@ -50,9 +61,6 @@ jq '.paths.ibc01.dst["client-id"]' < $RLY_CONFIG
 # Each service polls its target chain and stores ELC update records in a local SQLite DB,
 # then serves them via gRPC so that activate-client can use them instead of querying
 # the LCP enclave directly.
-ELC_UPDATER_DB_0=/tmp/elc-updater-ibc0.sqlite
-ELC_UPDATER_DB_1=/tmp/elc-updater-ibc1.sqlite
-
 $RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_0
 $RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_1
 
@@ -84,16 +92,25 @@ sleep 15
 # Enable ELC updater gRPC mode for activate-client and subsequent commands
 export YRLY_LCP_ELC_UPDATER_GRPC_ENABLE=true
 
+dump_elc_records
+echo "=== Running activate-client (src) ==="
 retry 5 $RLY lcp activate-client $PATH_NAME --src=true
+
+dump_elc_records
+echo "=== Running activate-client (dst) ==="
 retry 5 $RLY lcp activate-client $PATH_NAME --src=false
 sleep 3
 
+dump_elc_records
+echo "=== Running tx connection ==="
 retry 5 $RLY tx connection $PATH_NAME
 
 echo "=== Connection IDs ==="
 jq '.paths.ibc01.src["connection-id"]' < $RLY_CONFIG
 jq '.paths.ibc01.dst["connection-id"]' < $RLY_CONFIG
 
+dump_elc_records
+echo "=== Running tx channel ==="
 retry 5 $RLY tx channel $PATH_NAME
 
 echo "=== Channel IDs ==="

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -21,6 +21,7 @@ retry() {
 }
 
 RLY="${RLY_BIN} --debug"
+RLY_CONFIG="$HOME/.yui-relayer/config/config.json"
 
 CHAINID_ONE=ibc0
 RLYKEY=testkey
@@ -36,9 +37,6 @@ retry 5 $RLY lcp-tendermint light init $CHAINID_TWO -f
 
 # add a path between chain0 and chain1
 $RLY paths add $CHAINID_ONE $CHAINID_TWO $PATH_NAME --file=./configs/path.json
-
-retry 5 $RLY tx clients $PATH_NAME
-sleep 3
 
 # Start ELC updater services for both chains.
 # Each service polls its target chain and stores ELC update records in a local SQLite DB,
@@ -72,15 +70,31 @@ cleanup_elc_updaters() {
 }
 trap cleanup_elc_updaters EXIT
 
-# Give ELC updater services time to start and produce initial records
-echo "Waiting for ELC updater services to produce records..."
-sleep 15
+# Give ELC updater services time to start
+sleep 5
 
-# Enable ELC updater gRPC mode for activate-client and subsequent commands
+# Enable ELC updater gRPC mode for all subsequent commands
 export YRLY_LCP_ELC_UPDATER_GRPC_ENABLE=true
+
+retry 5 $RLY tx clients $PATH_NAME
+sleep 3
+
+echo "=== Client IDs ==="
+jq '.paths.ibc01.src["client-id"]' < $RLY_CONFIG
+jq '.paths.ibc01.dst["client-id"]' < $RLY_CONFIG
 
 retry 5 $RLY lcp activate-client $PATH_NAME --src=true
 retry 5 $RLY lcp activate-client $PATH_NAME --src=false
 sleep 3
+
 retry 5 $RLY tx connection $PATH_NAME
+
+echo "=== Connection IDs ==="
+jq '.paths.ibc01.src["connection-id"]' < $RLY_CONFIG
+jq '.paths.ibc01.dst["connection-id"]' < $RLY_CONFIG
+
 retry 5 $RLY tx channel $PATH_NAME
+
+echo "=== Channel IDs ==="
+jq '.paths.ibc01.src["channel-id"]' < $RLY_CONFIG
+jq '.paths.ibc01.dst["channel-id"]' < $RLY_CONFIG

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -28,17 +28,6 @@ RLYKEY=testkey
 CHAINID_TWO=ibc1
 PATH_NAME=ibc01
 
-# Helper to dump ELC updater DB contents for both chains
-dump_elc_records() {
-    echo "=== ELC updater records for $CHAINID_ONE ==="
-    $RLY lcp elc-updater dblist --sqlite-path $ELC_UPDATER_DB_0 2>/dev/null || true
-    echo "=== ELC updater records for $CHAINID_TWO ==="
-    $RLY lcp elc-updater dblist --sqlite-path $ELC_UPDATER_DB_1 2>/dev/null || true
-}
-
-ELC_UPDATER_DB_0=/tmp/elc-updater-ibc0.sqlite
-ELC_UPDATER_DB_1=/tmp/elc-updater-ibc1.sqlite
-
 $RLY tendermint keys show $CHAINID_ONE $RLYKEY
 $RLY tendermint keys show $CHAINID_TWO $RLYKEY
 
@@ -61,6 +50,9 @@ jq '.paths.ibc01.dst["client-id"]' < $RLY_CONFIG
 # Each service polls its target chain and stores ELC update records in a local SQLite DB,
 # then serves them via gRPC so that activate-client can use them instead of querying
 # the LCP enclave directly.
+ELC_UPDATER_DB_0=/tmp/elc-updater-ibc0.sqlite
+ELC_UPDATER_DB_1=/tmp/elc-updater-ibc1.sqlite
+
 $RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_0
 $RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_1
 
@@ -92,12 +84,7 @@ sleep 15
 # Enable ELC updater gRPC mode for activate-client and subsequent commands
 export YRLY_LCP_ELC_UPDATER_GRPC_ENABLE=true
 
-dump_elc_records
-echo "=== Running activate-client (src) ==="
 retry 5 $RLY lcp activate-client $PATH_NAME --src=true
-
-dump_elc_records
-echo "=== Running activate-client (dst) ==="
 retry 5 $RLY lcp activate-client $PATH_NAME --src=false
 sleep 3
 
@@ -115,8 +102,6 @@ echo "=== Connection IDs ==="
 jq '.paths.ibc01.src["connection-id"]' < $RLY_CONFIG
 jq '.paths.ibc01.dst["connection-id"]' < $RLY_CONFIG
 
-dump_elc_records
-echo "=== Running tx channel ==="
 retry 5 $RLY tx channel $PATH_NAME
 
 echo "=== Channel IDs ==="

--- a/tests/e2e/cases/tm2tm/scripts/handshake
+++ b/tests/e2e/cases/tm2tm/scripts/handshake
@@ -53,6 +53,7 @@ jq '.paths.ibc01.dst["client-id"]' < $RLY_CONFIG
 ELC_UPDATER_DB_0=/tmp/elc-updater-ibc0.sqlite
 ELC_UPDATER_DB_1=/tmp/elc-updater-ibc1.sqlite
 
+rm -f $ELC_UPDATER_DB_0 $ELC_UPDATER_DB_1
 $RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_0
 $RLY lcp elc-updater dbinit --sqlite-path $ELC_UPDATER_DB_1
 


### PR DESCRIPTION
Activating a client requires updating the EKI, which involves:

* Registering the enclave key in the counterparty chain.
* Confirming that the transaction to register the enclave key in the counterparty was finalized.

To confirm finality, the Relayer needs to query the counterparty using GetLatestFinalizedHeader(), then check if the transaction's block height is lower than the finalized height, or not.

If ELC updater is not in use, GetLatestFinalizedHeader() queries the origin prover directly. But if ELC updater is in use, it tries to get the latest record available from ELC updater.

The problem is that before this commit, ELC updater itself cannot insert any record because:

* It needs to update the ELC before any record can be inserted.
* To update the ELC, it needs to call SetupHeadersForUpdate() which queries the on-chain light client.
* But the on-chain light client is not activated yet, so the state is zeroed-out.

So there's a chicken-and-egg problem: activation requires records, but records can't be produced until activation is done.

This commit fixes the issue by making ELC updater's call to SetupHeadersForUpdate() query the ELC in LCP instead of querying the on-chain light client when there are no records yet. This works because the ELC has non-zero state when the client creation step of the handshake is done, and it's the [same thing that updateELC() does](https://github.com/datachainlab/lcp-go/blob/e2f6a88988a558582969232b1bcb57666fa5b852/relay/lcp.go#L399).